### PR TITLE
refactor: omit unnecessary reassignment

### DIFF
--- a/x/uexecutor/keeper/msg_server_test.go
+++ b/x/uexecutor/keeper/msg_server_test.go
@@ -49,7 +49,6 @@ func TestParams(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := f.msgServer.UpdateParams(f.ctx, tc.request)
 

--- a/x/uregistry/keeper/msg_server_test.go
+++ b/x/uregistry/keeper/msg_server_test.go
@@ -36,7 +36,6 @@ func TestParams(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := f.msgServer.UpdateParams(f.ctx, tc.request)
 

--- a/x/utxverifier/keeper/msg_server_test.go
+++ b/x/utxverifier/keeper/msg_server_test.go
@@ -36,7 +36,6 @@ func TestParams(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := f.msgServer.UpdateParams(f.ctx, tc.request)
 

--- a/x/uvalidator/keeper/msg_server_test.go
+++ b/x/uvalidator/keeper/msg_server_test.go
@@ -36,7 +36,6 @@ func TestParams(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := f.msgServer.UpdateParams(f.ctx, tc.request)
 


### PR DESCRIPTION
The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore