### PR TITLE
docs: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Bug Report
+
+### Expected Behavior
+
+### Actual Behavior
+
+### Steps to Reproduce
+
+### Version
+- Go version: `go version`
+- Commit: 
+
+### Environment
+- OS: 
+- Other:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Feature Request
+
+### Motivation
+
+### Proposal
+
+### Alternatives Considered

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+Brief description of changes.
+
+## References
+- Fixes #
+- Related issue/PR: 
+
+## Changes
+- 
+
+## Testing
+- `go test ./...`
+
+## Checklist
+- [ ] Ready for review
+- [ ] Docs updated (if applicable)
+- [ ] Env vars updated (if applicable)


### PR DESCRIPTION
FIXES #27 

- Add pull_request_template.md with summary, references, changes, testing, and checklist sections
- Add bug_report.md issue template with expected/actual behavior, steps to reproduce, version, and environment
- Add feature_request.md issue template with motivation, proposal, and alternatives sections


- Ref: [ethereum/go-ethereum/.github](https://github.com/ethereum/go-ethereum/tree/master/.github)