### PR TITLE
feat: Added burner permission to feeCollector permission for baseFeeBurn

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -234,7 +234,7 @@ var (
 
 // module account permissions
 var maccPerms = map[string][]string{
-	authtypes.FeeCollectorName:     nil,
+	authtypes.FeeCollectorName:     {authtypes.Burner},
 	distrtypes.ModuleName:          nil,
 	minttypes.ModuleName:           {authtypes.Minter},
 	stakingtypes.BondedPoolName:    {authtypes.Burner, authtypes.Staking},

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ replace (
 	cosmossdk.io/x/upgrade => cosmossdk.io/x/upgrade v0.1.4
 	github.com/CosmWasm/wasmd => github.com/CosmWasm/wasmd v0.55.0 // Keep v0.55.0
 	github.com/cosmos/cosmos-sdk => github.com/cosmos/cosmos-sdk v0.50.10 // Use stable v0.50.10
-	github.com/cosmos/evm => github.com/pushchain/evm v0.2.1-0.20251013112033-ffd15b85335c
+	github.com/cosmos/evm => github.com/pushchain/evm v0.2.1-0.20251210080938-3cfc2b90d069
 	github.com/ethereum/go-ethereum => github.com/cosmos/go-ethereum v1.10.26-evmos-rc4.0.20250402013457-cf9d288f0147
 	github.com/spf13/viper => github.com/spf13/viper v1.17.0
 	github.com/strangelove-ventures/tokenfactory => github.com/strangelove-ventures/tokenfactory v0.50.7-wasmvm2

--- a/go.sum
+++ b/go.sum
@@ -1622,8 +1622,8 @@ github.com/prysmaticlabs/gohashtree v0.0.4-beta.0.20240624100937-73632381301b h1
 github.com/prysmaticlabs/gohashtree v0.0.4-beta.0.20240624100937-73632381301b/go.mod h1:HRuvtXLZ4WkaB1MItToVH2e8ZwKwZPY5/Rcby+CvvLY=
 github.com/prysmaticlabs/prysm/v5 v5.3.0 h1:7Lr8ndapBTZg00YE+MgujN6+yvJR6Bdfn28ZDSJ00II=
 github.com/prysmaticlabs/prysm/v5 v5.3.0/go.mod h1:r1KhlduqDMIGZ1GhR5pjZ2Ko8Q89noTDYTRoPKwf1+c=
-github.com/pushchain/evm v0.2.1-0.20251013112033-ffd15b85335c h1:V9/cXTaDtXJJAMuTFwfOYgCcPzO03YGxu462/vU0+pI=
-github.com/pushchain/evm v0.2.1-0.20251013112033-ffd15b85335c/go.mod h1:/4D24vd1xRnUVaXzfNryxTo5Gn1c/phJG5FvpH9OvLQ=
+github.com/pushchain/evm v0.2.1-0.20251210080938-3cfc2b90d069 h1:cmN8Si7hTt8VepGeO9bhb60GJvc2oQxyD182OUtKUSQ=
+github.com/pushchain/evm v0.2.1-0.20251210080938-3cfc2b90d069/go.mod h1:/4D24vd1xRnUVaXzfNryxTo5Gn1c/phJG5FvpH9OvLQ=
 github.com/rakyll/statik v0.1.7 h1:OF3QCZUuyPxuGEP7B4ypUa7sB/iHtqOTDYZXGM8KOdQ=
 github.com/rakyll/statik v0.1.7/go.mod h1:AlZONWzMtEnMs7W4e/1LURLiI49pIMmp6V9Unghqrcc=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=


### PR DESCRIPTION
## Summary
Made some changes to burn gas fees in the `pushchain/evm` repo, in the `ApplyTransaction()` function. It basically burns the BaseFee tokens from the `feeCollector` module so they are not distributed to validators.

## References
- Fixes #
- Related issue/PR: https://github.com/pushchain/evm/pull/4

## Changes
- `app.go` : Changed feeCollector module's permissions from `nil` to `authtypes.Burner`
- `go.mod` : Updated evm version.

## Testing
- `go test ./...`

## Checklist
- [x] Ready for review
- [ ] Docs updated (if applicable)
- [ ] Env vars updated (if applicable)
