### PR TITLE
fix: Update ExtraEIP parameter format for EVM v0.2.0 compatibility

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -13,6 +13,7 @@ import (
 	pcmintcap "github.com/pushchain/push-chain-node/app/upgrades/pc-mint-cap"
 	solanafix "github.com/pushchain/push-chain-node/app/upgrades/solana-fix"
 	tsscore "github.com/pushchain/push-chain-node/app/upgrades/tss-core"
+	tsscoreevmparamsfix "github.com/pushchain/push-chain-node/app/upgrades/tss-core-evm-params-fix"
 	tsscorefix "github.com/pushchain/push-chain-node/app/upgrades/tss-core-fix"
 )
 
@@ -25,6 +26,7 @@ var Upgrades = []upgrades.Upgrade{
 	pcmintcap.NewUpgrade(),
 	tsscore.NewUpgrade(),
 	tsscorefix.NewUpgrade(),
+	tsscoreevmparamsfix.NewUpgrade(),
 }
 
 // RegisterUpgradeHandlers registers the chain upgrade handlers
@@ -42,6 +44,7 @@ func (app *ChainApp) RegisterUpgradeHandlers() {
 		IBCKeeper:             app.IBCKeeper,
 		Codec:                 app.appCodec,
 		GetStoreKey:           app.GetKey,
+		EVMKeeper:             app.EVMKeeper,
 
 		// Module keepers
 		UExecutorKeeper:   &app.UexecutorKeeper,

--- a/app/upgrades/tss-core-evm-params-fix/upgrade.go
+++ b/app/upgrades/tss-core-evm-params-fix/upgrade.go
@@ -1,0 +1,53 @@
+package inbound
+
+import (
+	"context"
+	"fmt"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	storetypes "cosmossdk.io/store/types"
+	"github.com/pushchain/push-chain-node/app/upgrades"
+	utsstypes "github.com/pushchain/push-chain-node/x/utss/types"
+)
+
+const UpgradeName = "tss-core-evm-params-fix"
+
+// NewUpgrade constructs the upgrade definition
+func NewUpgrade() upgrades.Upgrade {
+	return upgrades.Upgrade{
+		UpgradeName:          UpgradeName,
+		CreateUpgradeHandler: CreateUpgradeHandler,
+		StoreUpgrades: storetypes.StoreUpgrades{
+			Added:   []string{utsstypes.StoreKey},
+			Deleted: []string{},
+		},
+	}
+}
+
+func CreateUpgradeHandler(
+	mm upgrades.ModuleManager,
+	configurator module.Configurator,
+	ak *upgrades.AppKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx context.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		sdkCtx := sdk.UnwrapSDKContext(ctx)
+		sdkCtx.Logger().Info("🔧 Running upgrade:", "name", UpgradeName)
+		sdkCtx.Logger().Info("=== Starting EVM params fix upgrade ===")
+
+		// Get current corrupted params
+		evmParams := ak.EVMKeeper.GetParams(sdkCtx)
+		sdkCtx.Logger().Info("Current corrupted extra_eips", "value", evmParams.ExtraEIPs)
+
+		// Fix ExtraEIPs - replace corrupted ASCII values with proper EIP number
+		evmParams.ExtraEIPs = []int64{3855}
+
+		if err := ak.EVMKeeper.SetParams(sdkCtx, evmParams); err != nil {
+			return nil, fmt.Errorf("failed to set EVM params: %w", err)
+		}
+		// Run module migrations
+		return mm.RunMigrations(ctx, configurator, fromVM)
+	}
+}


### PR DESCRIPTION
## Summary
## Problem

Following the migration from `pushchain/evm` v0.1.0 to v0.2.0, the format for passing `ExtraEIP` parameters has changed, causing EVM transaction failures.

**Previous format (v0.1.0):**
```go
extraEIP = ["ethereum_3855"]
```

**New format (v0.2.0):**
```go
extraEIP = [3855]
```

## Impact

The format mismatch caused the EVM interpreter to misinterpret the string `"ethereum_3855"` as individual ASCII character codes (101, 104, 114, 117, 95, 56, 53), resulting in multiple EIP activation failures:
```
9:18AM ERR EIP activation failed error="undefined eip 101" eip=101 module=geth
9:18AM ERR EIP activation failed error="undefined eip 104" eip=104 module=geth
9:18AM ERR EIP activation failed error="undefined eip 114" eip=114 module=geth
9:18AM ERR EIP activation failed error="undefined eip 117" eip=117 module=geth
9:18AM ERR EIP activation failed error="undefined eip 95" eip=95 module=geth
9:18AM ERR EIP activation failed error="undefined eip 56" eip=56 module=geth
9:18AM ERR EIP activation failed error="undefined eip 53" eip=53 module=geth
```

## Solution

Updated EVM parameters to use the new integer-based format for EIP specification. Modified the upgrade handler to properly handle this breaking change from the EVM library migration.

## References
- Fixes #
- Related issue/PR: https://github.com/pushchain/evm/pull/2

## Changes

- Updated `ExtraEIP` parameter format to match v0.2.0 specification
- Modified upgrade handler to accommodate the new EVM parameter structure


## Testing
- `go test ./...`

## Checklist
- [ ] Ready for review
- [ ] Docs updated (if applicable)
- [ ] Env vars updated (if applicable)
