### PR TITLE
fix: event Skipping via Pagination Failure in Solana Event Listener

### DIFF
--- a/universalClient/chains/svm/event_listener.go
+++ b/universalClient/chains/svm/event_listener.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gagliardetto/solana-go"
+	solanarpc "github.com/gagliardetto/solana-go/rpc"
 	"github.com/rs/zerolog"
 
 	"github.com/pushchain/push-chain-node/universalClient/chains/common"
@@ -17,10 +18,23 @@ import (
 	uregistrytypes "github.com/pushchain/push-chain-node/x/uregistry/types"
 )
 
+// Warn (not refuse) once a single poll has processed this many in-range sigs;
+// re-emitted per subsequent page so ops sees a sustained signal, not a blip.
+const largePollWarnThreshold uint64 = 100_000
+
+// rpcClientInterface is the subset of *RPCClient methods the listener depends on.
+// Defined as an interface so tests can supply a mock without spinning up a real
+// JSON-RPC server. *RPCClient satisfies it implicitly.
+type rpcClientInterface interface {
+	GetLatestSlot(ctx context.Context) (uint64, error)
+	GetSignaturesForAddress(ctx context.Context, address solana.PublicKey, before solana.Signature) ([]*solanarpc.TransactionSignature, error)
+	GetTransaction(ctx context.Context, signature solana.Signature) (*solanarpc.GetTransactionResult, error)
+}
+
 // EventListener listens for gateway events on SVM chains and stores them in the database
 type EventListener struct {
 	// Core dependencies
-	rpcClient  *RPCClient
+	rpcClient  rpcClientInterface
 	chainStore *common.ChainStore
 	database   *db.DB
 
@@ -40,7 +54,7 @@ type EventListener struct {
 
 // NewEventListener creates a new SVM event listener
 func NewEventListener(
-	rpcClient *RPCClient,
+	rpcClient rpcClientInterface,
 	gatewayAddress string,
 	chainID string,
 	gatewayMethods []*uregistrytypes.GatewayMethods,
@@ -206,20 +220,72 @@ func (el *EventListener) processSlotRange(
 		return fmt.Errorf("invalid gateway address: %w", err)
 	}
 
-	// Get signatures for the gateway program
-	signatures, err := el.rpcClient.GetSignaturesForAddress(ctx, gatewayAddr)
-	if err != nil {
-		return fmt.Errorf("failed to get signatures: %w", err)
+	// Per-page streaming so memory stays bounded on long bootstraps. Termination
+	// and cursor use min(slot) of the batch — per
+	// https://github.com/solana-labs/solana/issues/22456 in-page order is not
+	// guaranteed descending, so batch[len-1] would risk an early break.
+	var beforeSig solana.Signature
+	var processedInRange uint64
+	for page := 0; ; page++ {
+		batch, err := el.rpcClient.GetSignaturesForAddress(ctx, gatewayAddr, beforeSig)
+		if err != nil {
+			return fmt.Errorf("failed to get signatures (page %d): %w", page, err)
+		}
+		if len(batch) == 0 {
+			break
+		}
+
+		processed, err := el.processSignatureBatch(ctx, batch, fromSlot, toSlot)
+		if err != nil {
+			return err
+		}
+		processedInRange += processed
+		if processedInRange >= largePollWarnThreshold {
+			el.logger.Warn().
+				Uint64("processed_in_range", processedInRange).
+				Uint64("threshold", largePollWarnThreshold).
+				Uint64("from_slot", fromSlot).
+				Uint64("to_slot", toSlot).
+				Int("pages", page+1).
+				Msg("large signature backlog being processed; if this is unexpected, " +
+					"restart with EventStartFrom set to -1 (latest) or a recent slot, " +
+					"and verify the RPC tier can sustain the request volume")
+		}
+
+		minSlot := batch[0].Slot
+		minSig := batch[0].Signature
+		for _, s := range batch[1:] {
+			if s.Slot < minSlot {
+				minSlot = s.Slot
+				minSig = s.Signature
+			}
+		}
+
+		if minSlot < fromSlot {
+			break
+		}
+		beforeSig = minSig
 	}
 
-	// Process signatures in the slot range
-	for _, sig := range signatures {
+	return nil
+}
+
+// Processes in-range sigs from `batch`, returns how many. `continue` on both
+// bounds so it tolerates any in-page order.
+func (el *EventListener) processSignatureBatch(
+	ctx context.Context,
+	batch []*solanarpc.TransactionSignature,
+	fromSlot, toSlot uint64,
+) (uint64, error) {
+	var processed uint64
+	for _, sig := range batch {
 		if sig.Slot < fromSlot {
 			continue
 		}
 		if sig.Slot > toSlot {
-			break
+			continue
 		}
+		processed++
 
 		// Get transaction details
 		tx, err := el.rpcClient.GetTransaction(ctx, sig.Signature)
@@ -264,7 +330,7 @@ func (el *EventListener) processSlotRange(
 		}
 	}
 
-	return nil
+	return processed, nil
 }
 
 // getStartSlot returns the slot to start watching from

--- a/universalClient/chains/svm/event_listener_test.go
+++ b/universalClient/chains/svm/event_listener_test.go
@@ -1,12 +1,16 @@
 package svm
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/hex"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/gagliardetto/solana-go"
+	solanarpc "github.com/gagliardetto/solana-go/rpc"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,6 +18,53 @@ import (
 	"github.com/pushchain/push-chain-node/universalClient/db"
 	uregistrytypes "github.com/pushchain/push-chain-node/x/uregistry/types"
 )
+
+// mockRPCClient implements rpcClientInterface for tests. Pages are returned
+// from `signaturePages` in order; the cursor passed to each call is recorded
+// in `sigCallCursors` for assertion. GetTransaction returns (nil, nil) so the
+// in-range branch increments `processed` but does no event parsing — keeps
+// tests focused on pagination/cursor behavior.
+type mockRPCClient struct {
+	latestSlot     uint64
+	signaturePages [][]*solanarpc.TransactionSignature
+	sigCallCursors []solana.Signature
+	txCalls        []solana.Signature
+}
+
+func (m *mockRPCClient) GetLatestSlot(ctx context.Context) (uint64, error) {
+	return m.latestSlot, nil
+}
+
+func (m *mockRPCClient) GetSignaturesForAddress(ctx context.Context, address solana.PublicKey, before solana.Signature) ([]*solanarpc.TransactionSignature, error) {
+	idx := len(m.sigCallCursors)
+	m.sigCallCursors = append(m.sigCallCursors, before)
+	if idx >= len(m.signaturePages) {
+		return nil, nil
+	}
+	return m.signaturePages[idx], nil
+}
+
+func (m *mockRPCClient) GetTransaction(ctx context.Context, signature solana.Signature) (*solanarpc.GetTransactionResult, error) {
+	m.txCalls = append(m.txCalls, signature)
+	return nil, nil
+}
+
+// mkSig builds a deterministic non-zero solana.Signature from a single byte seed.
+// Seed 0 is reserved (would collide with the zero-value cursor).
+func mkSig(seed byte) solana.Signature {
+	var s solana.Signature
+	for i := range s {
+		s[i] = seed
+	}
+	return s
+}
+
+func mkSigInfo(slot uint64, seed byte) *solanarpc.TransactionSignature {
+	return &solanarpc.TransactionSignature{
+		Slot:      slot,
+		Signature: mkSig(seed),
+	}
+}
 
 func TestNewEventListener_Valid(t *testing.T) {
 	logger := zerolog.Nop()
@@ -309,6 +360,206 @@ func TestEventListener_GetStartSlotFromConfig(t *testing.T) {
 			el.getStartSlotFromConfig(context.Background())
 		})
 	})
+}
+
+func TestEventListener_ProcessSignatureBatch_NoRPCCalls(t *testing.T) {
+	logger := zerolog.Nop()
+
+	// Constructed with nil rpcClient — these scenarios must early-return (via the
+	// bounds-check `continue`s) before any RPC call would be made.
+	el, err := NewEventListener(nil, "GatewayAddr", "solana:test", nil, nil, 5, nil, logger)
+	require.NoError(t, err)
+
+	t.Run("empty batch returns 0", func(t *testing.T) {
+		processed, err := el.processSignatureBatch(context.Background(), nil, 100, 200)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(0), processed)
+	})
+
+	t.Run("all sigs below fromSlot return 0", func(t *testing.T) {
+		batch := []*solanarpc.TransactionSignature{
+			{Slot: 50}, {Slot: 75}, {Slot: 99},
+		}
+		processed, err := el.processSignatureBatch(context.Background(), batch, 100, 200)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(0), processed)
+	})
+
+	t.Run("all sigs above toSlot return 0 without break", func(t *testing.T) {
+		// Regression guard: an upper-bound `break` here would short-circuit;
+		// `continue` must skip past sigs > toSlot without aborting. All-above
+		// sigs all skip via continue; processed must be 0.
+		batch := []*solanarpc.TransactionSignature{
+			{Slot: 250}, {Slot: 300}, {Slot: 999},
+		}
+		processed, err := el.processSignatureBatch(context.Background(), batch, 100, 200)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(0), processed)
+	})
+
+	t.Run("mixed out-of-range sigs (above and below) return 0", func(t *testing.T) {
+		// Mixed unordered batch with no in-range entries — exercises both
+		// continue branches without invoking the RPC.
+		batch := []*solanarpc.TransactionSignature{
+			{Slot: 250}, {Slot: 50}, {Slot: 999}, {Slot: 75},
+		}
+		processed, err := el.processSignatureBatch(context.Background(), batch, 100, 200)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(0), processed)
+	})
+}
+
+func TestEventListener_ProcessSlotRange(t *testing.T) {
+	logger := zerolog.Nop()
+	gateway := solana.SystemProgramID.String() // any valid base58 pubkey
+
+	setup := func(t *testing.T, mock *mockRPCClient) *EventListener {
+		database, err := db.OpenInMemoryDB(true)
+		require.NoError(t, err)
+		el, err := NewEventListener(mock, gateway, "solana:test", nil, database, 5, nil, logger)
+		require.NoError(t, err)
+		return el
+	}
+
+	t.Run("single page, minSlot below fromSlot terminates loop", func(t *testing.T) {
+		// Page slots [100, 90, 80, 70, 60]. Window [85, 200]. min=60 < fromSlot=85 → break.
+		// In-range = slots 100, 90 → 2 GetTransaction calls.
+		mock := &mockRPCClient{
+			signaturePages: [][]*solanarpc.TransactionSignature{
+				{
+					mkSigInfo(100, 1),
+					mkSigInfo(90, 2),
+					mkSigInfo(80, 3),
+					mkSigInfo(70, 4),
+					mkSigInfo(60, 5),
+				},
+			},
+		}
+		el := setup(t, mock)
+
+		err := el.processSlotRange(context.Background(), 85, 200)
+		require.NoError(t, err)
+
+		require.Len(t, mock.sigCallCursors, 1)
+		assert.True(t, mock.sigCallCursors[0].IsZero(), "first call should use zero cursor")
+		require.Len(t, mock.txCalls, 2)
+		assert.Equal(t, mkSig(1), mock.txCalls[0])
+		assert.Equal(t, mkSig(2), mock.txCalls[1])
+	})
+
+	t.Run("multi-page, cursor advances to min-slot sig", func(t *testing.T) {
+		// Page 0: [200, 150]. Page 1: [100, 50]. Window [70, 300].
+		// After page 0 minSlot=150 ≥ 70 → continue with cursor = mkSig(2) (slot 150).
+		// After page 1 minSlot=50 < 70 → break.
+		mock := &mockRPCClient{
+			signaturePages: [][]*solanarpc.TransactionSignature{
+				{mkSigInfo(200, 1), mkSigInfo(150, 2)},
+				{mkSigInfo(100, 3), mkSigInfo(50, 4)},
+			},
+		}
+		el := setup(t, mock)
+
+		err := el.processSlotRange(context.Background(), 70, 300)
+		require.NoError(t, err)
+
+		require.Len(t, mock.sigCallCursors, 2)
+		assert.True(t, mock.sigCallCursors[0].IsZero())
+		assert.Equal(t, mkSig(2), mock.sigCallCursors[1], "page-1 cursor must be page-0 min-slot sig")
+		// In-range = 200, 150, 100 (50 below window)
+		require.Len(t, mock.txCalls, 3)
+	})
+
+	t.Run("empty page terminates immediately", func(t *testing.T) {
+		mock := &mockRPCClient{
+			signaturePages: [][]*solanarpc.TransactionSignature{{}},
+		}
+		el := setup(t, mock)
+
+		err := el.processSlotRange(context.Background(), 0, 1000)
+		require.NoError(t, err)
+
+		assert.Len(t, mock.sigCallCursors, 1)
+		assert.Empty(t, mock.txCalls)
+	})
+
+	t.Run("high-slot leading sig does not abort iteration", func(t *testing.T) {
+		// Order [{300}, {150}, {100}] — first sig is above toSlot=200. With buggy
+		// `break` on upper bound, sigs at 150 and 100 would be missed. With `continue`,
+		// both are processed. fromSlot=50 keeps both in range; minSlot=100 > 50 → loop
+		// fetches a second (empty) page and terminates there.
+		mock := &mockRPCClient{
+			signaturePages: [][]*solanarpc.TransactionSignature{
+				{mkSigInfo(300, 1), mkSigInfo(150, 2), mkSigInfo(100, 3)},
+			},
+		}
+		el := setup(t, mock)
+
+		err := el.processSlotRange(context.Background(), 50, 200)
+		require.NoError(t, err)
+
+		require.Len(t, mock.txCalls, 2, "in-range sigs after the leading out-of-range one must still be processed")
+		assert.Equal(t, mkSig(2), mock.txCalls[0])
+		assert.Equal(t, mkSig(3), mock.txCalls[1])
+	})
+
+	t.Run("cursor uses min-slot sig regardless of array position (https://github.com/solana-labs/solana/issues/22456)", func(t *testing.T) {
+		// Page 0 unordered: [200, 50, 150, 80]. min slot = 50 (mkSig(2)).
+		// Window [41, 1000] → page 0 minSlot=50 ≥ 41 → continue with cursor = mkSig(2).
+		// Page 1: [40] → minSlot=40 < 41 → break.
+		mock := &mockRPCClient{
+			signaturePages: [][]*solanarpc.TransactionSignature{
+				{mkSigInfo(200, 1), mkSigInfo(50, 2), mkSigInfo(150, 3), mkSigInfo(80, 4)},
+				{mkSigInfo(40, 5)},
+			},
+		}
+		el := setup(t, mock)
+
+		err := el.processSlotRange(context.Background(), 41, 1000)
+		require.NoError(t, err)
+
+		require.Len(t, mock.sigCallCursors, 2)
+		assert.Equal(t, mkSig(2), mock.sigCallCursors[1], "page-1 cursor must be the min-slot sig from page 0, not batch[len-1]")
+		// All 4 page-0 sigs are in-range (200, 50, 150, 80 all > 41); page-1 sig at slot 40 is not
+		require.Len(t, mock.txCalls, 4)
+	})
+}
+
+func TestEventListener_LargePollWarning(t *testing.T) {
+	// Build pages that cumulatively cross largePollWarnThreshold (100k). Threshold is
+	// reached after 100 pages of 1000; we add 5 more pages so the warning re-fires
+	// for each subsequent page while the condition holds.
+	const pagesAfterThreshold = 5
+	const totalPages = int(largePollWarnThreshold/1000) + pagesAfterThreshold
+
+	pages := make([][]*solanarpc.TransactionSignature, 0, totalPages+1)
+	slot := uint64(2_000_000)
+	for p := 0; p < totalPages; p++ {
+		page := make([]*solanarpc.TransactionSignature, 1000)
+		for i := 0; i < 1000; i++ {
+			slot--
+			// Seed varies per page to give each page a distinct min-slot sig.
+			page[i] = &solanarpc.TransactionSignature{Slot: slot, Signature: mkSig(byte((p % 254) + 1))}
+		}
+		pages = append(pages, page)
+	}
+	pages = append(pages, []*solanarpc.TransactionSignature{}) // empty page terminates
+
+	mock := &mockRPCClient{signaturePages: pages}
+	var logBuf bytes.Buffer
+	logger := zerolog.New(&logBuf).Level(zerolog.WarnLevel)
+	database, err := db.OpenInMemoryDB(true)
+	require.NoError(t, err)
+	el, err := NewEventListener(mock, solana.SystemProgramID.String(), "solana:test", nil, database, 5, nil, logger)
+	require.NoError(t, err)
+
+	err = el.processSlotRange(context.Background(), 0, 3_000_000)
+	require.NoError(t, err)
+
+	output := logBuf.String()
+	warnCount := strings.Count(output, "large signature backlog being processed")
+	// Warning fires once on the page that crosses 100k, and again on each subsequent
+	// page while still over threshold. With 5 pages added past threshold, expect 6 warns.
+	assert.GreaterOrEqual(t, warnCount, pagesAfterThreshold, "warning should re-emit per page while above threshold")
 }
 
 func TestEventListener_StopNotRunning(t *testing.T) {

--- a/universalClient/chains/svm/rpc_client.go
+++ b/universalClient/chains/svm/rpc_client.go
@@ -252,12 +252,19 @@ func calculateMedian(fees []uint64) uint64 {
 	return fees[n/2]
 }
 
-// GetSignaturesForAddress gets transaction signatures for an address
-func (rc *RPCClient) GetSignaturesForAddress(ctx context.Context, address solana.PublicKey) ([]*rpc.TransactionSignature, error) {
+// GetSignaturesForAddress gets transaction signatures for an address. If
+// `before` is the zero signature, fetching starts from the most recent block;
+// otherwise it returns signatures strictly older than `before`, enabling
+// backward pagination.
+func (rc *RPCClient) GetSignaturesForAddress(ctx context.Context, address solana.PublicKey, before solana.Signature) ([]*rpc.TransactionSignature, error) {
+	var opts *rpc.GetSignaturesForAddressOpts
+	if !before.IsZero() {
+		opts = &rpc.GetSignaturesForAddressOpts{Before: before}
+	}
 	var signatures []*rpc.TransactionSignature
 	err := rc.executeWithFailover(ctx, "get_signatures_for_address", func(client *rpc.Client) error {
 		var innerErr error
-		signatures, innerErr = client.GetSignaturesForAddress(ctx, address)
+		signatures, innerErr = client.GetSignaturesForAddressWithOpts(ctx, address, opts)
 		return innerErr
 	})
 	return signatures, err


### PR DESCRIPTION
Changes:

- Added backward pagination to `processSlotRange` (no page cap; min-slot signature drives both termination and the next cursor — robust against https://github.com/solana-labs/solana/issues/22456).
- Per-page streaming so memory stays bounded by one page regardless of backlog size.
- `WARN` log per page once a single poll exceeds 100k in-range sigs, with an actionable hint.
- Added test coverage for pagination, cursor selection, ordering robustness, and the warning behavior.