### PR TITLE
fix: tx success verification in event confirmer

### DIFF
--- a/universalClient/chains/evm/event_confirmer.go
+++ b/universalClient/chains/evm/event_confirmer.go
@@ -145,6 +145,19 @@ func (ec *EventConfirmer) processPendingEvents(ctx context.Context) error {
 			continue
 		}
 
+		// eth_getLogs only returns logs from txs with receipt status 1, so this
+		// branch should never fire on a healthy RPC. Kept as defense-in-depth and
+		// for symmetry with the SVM confirmer, which has a real path here.
+		if receipt.Status != 1 {
+			if _, updateErr := ec.chainStore.UpdateEventStatus(event.EventID, store.StatusPending, store.StatusReverted); updateErr != nil {
+				ec.logger.Error().
+					Err(updateErr).
+					Str("event_id", event.EventID).
+					Msg("failed to mark failed-tx event as REVERTED")
+			}
+			continue
+		}
+
 		// Check if transaction is confirmed based on confirmation type
 		requiredConfirmations := ec.getRequiredConfirmations(event.ConfirmationType)
 		confirmations := latestBlock - receipt.BlockNumber.Uint64() + 1

--- a/universalClient/chains/svm/event_confirmer.go
+++ b/universalClient/chains/svm/event_confirmer.go
@@ -158,6 +158,19 @@ func (ec *EventConfirmer) processPendingEvents(ctx context.Context) error {
 			continue
 		}
 
+		// Solana preserves meta.logMessages even when meta.err is set, so a Program
+		// data: line from a failed tx can reach the listener. Mark such events
+		// REVERTED here so they never promote to CONFIRMED and trigger a vote.
+		if tx.Meta.Err != nil {
+			if _, updateErr := ec.chainStore.UpdateEventStatus(event.EventID, store.StatusPending, store.StatusReverted); updateErr != nil {
+				ec.logger.Error().
+					Err(updateErr).
+					Str("event_id", event.EventID).
+					Msg("failed to mark failed-tx event as REVERTED")
+			}
+			continue
+		}
+
 		// Get transaction slot
 		txSlot := tx.Slot
 		if txSlot == 0 {


### PR DESCRIPTION
buildOutboundObservation is the success-path constructor - only successful destination txs reach it, which is why `Success` and `ErrorMsg` are constants.

EVM: logs come from eth_getLogs, which by chain protocol only returns logs from txs with receipt status 1.

Solana: meta.logMessages is preserved even when meta.err is set, so in principle a `Program data:` line from a failed tx could reach us.

I am proposing this as the fix -
Keep the success and errorMsg as it is ( ie hardcoded )
add a tx-status filter in the confirmers - tx.Meta.Err == nill for Solana - [svm_event_confirmer](https://github.com/pushchain/push-chain-node/blob/audit-fixes/universalClient/chains/svm/event_confirmer.go)
and receipt.Status == 1 for EVM [evm_event_confirmer](https://github.com/pushchain/push-chain-node/blob/audit-fixes/universalClient/chains/evm/event_confirmer.go)
The EVM one is redundant given `eth_getLogs` semantics but keeps the pattern symmetric.

Failure handling stays in txresolver (voteOutboundFailureAndMarkReverted), which polls receipts after broadcast and votes `Success: false` for reverted / not-found txs.