### PR TITLE
fix: blockscout evm derived txs issue

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -22,6 +22,7 @@ import (
 	evmchainidffix "github.com/pushchain/push-chain-node/app/upgrades/evm-chainid-fix"
 	evmpreinstalls "github.com/pushchain/push-chain-node/app/upgrades/evm-preinstalls"
 	ethhashfix "github.com/pushchain/push-chain-node/app/upgrades/eth-hash-fix"
+	evmblockscoutfix "github.com/pushchain/push-chain-node/app/upgrades/evm-blockscout-fix"
 	evmrpcfix "github.com/pushchain/push-chain-node/app/upgrades/evm-rpc-fix"
 	evmv040 "github.com/pushchain/push-chain-node/app/upgrades/evm-v0-4-0"
 	feeabs "github.com/pushchain/push-chain-node/app/upgrades/fee-abs"
@@ -52,6 +53,7 @@ var Upgrades = []upgrades.Upgrade{
 	tsscorefix.NewUpgrade(),
 	tsscoreevmparamsfix.NewUpgrade(),
 	evmrpcfix.NewUpgrade(),
+	evmblockscoutfix.NewUpgrade(),
 	tssvotegasless.NewUpgrade(),
 	removefeeabsv1.NewUpgrade(),
 	outbound.NewUpgrade(),

--- a/app/upgrades/evm-blockscout-fix/upgrade.go
+++ b/app/upgrades/evm-blockscout-fix/upgrade.go
@@ -1,0 +1,34 @@
+package evmblockscoutfix
+
+import (
+	"context"
+
+	storetypes "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/pushchain/push-chain-node/app/upgrades"
+)
+
+const UpgradeName = "evm-blockscout-fix"
+
+func NewUpgrade() upgrades.Upgrade {
+	return upgrades.Upgrade{
+		UpgradeName:          UpgradeName,
+		CreateUpgradeHandler: CreateUpgradeHandler,
+		StoreUpgrades: storetypes.StoreUpgrades{
+			Added:   []string{},
+			Deleted: []string{},
+		},
+	}
+}
+
+func CreateUpgradeHandler(
+	mm upgrades.ModuleManager,
+	configurator module.Configurator,
+	ak *upgrades.AppKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx context.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		return mm.RunMigrations(ctx, configurator, fromVM)
+	}
+}

--- a/app/upgrades/evm-rpc-fix/upgrade.go
+++ b/app/upgrades/evm-rpc-fix/upgrade.go
@@ -1,4 +1,4 @@
-package inbound
+package evmrpcfix
 
 import (
 	"context"

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ replace (
 	cosmossdk.io/x/upgrade => cosmossdk.io/x/upgrade v0.1.4
 	github.com/CosmWasm/wasmd => github.com/CosmWasm/wasmd v0.55.0 // Keep v0.55.0
 	github.com/cosmos/cosmos-sdk => github.com/cosmos/cosmos-sdk v0.50.10 // Use stable v0.50.10
-	github.com/cosmos/evm => github.com/pushchain/evm v1.0.0-rc2.0.20260603074055-8f9a31adb5dc
+	github.com/cosmos/evm => github.com/pushchain/evm v1.0.0-rc2.0.20260604090552-d3251a04c5b2
 	github.com/ethereum/go-ethereum => github.com/cosmos/go-ethereum v0.0.0-20250806193535-2fc7571efa91
 	github.com/spf13/viper => github.com/spf13/viper v1.17.0
 	github.com/strangelove-ventures/tokenfactory => github.com/strangelove-ventures/tokenfactory v0.50.7-wasmvm2

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ replace (
 	cosmossdk.io/x/upgrade => cosmossdk.io/x/upgrade v0.1.4
 	github.com/CosmWasm/wasmd => github.com/CosmWasm/wasmd v0.55.0 // Keep v0.55.0
 	github.com/cosmos/cosmos-sdk => github.com/cosmos/cosmos-sdk v0.50.10 // Use stable v0.50.10
-	github.com/cosmos/evm => github.com/pushchain/evm v1.0.0-rc2.0.20260518124843-b5053b7ed645
+	github.com/cosmos/evm => github.com/pushchain/evm v1.0.0-rc2.0.20260603074055-8f9a31adb5dc
 	github.com/ethereum/go-ethereum => github.com/cosmos/go-ethereum v0.0.0-20250806193535-2fc7571efa91
 	github.com/spf13/viper => github.com/spf13/viper v1.17.0
 	github.com/strangelove-ventures/tokenfactory => github.com/strangelove-ventures/tokenfactory v0.50.7-wasmvm2

--- a/go.sum
+++ b/go.sum
@@ -1769,8 +1769,8 @@ github.com/prysmaticlabs/gohashtree v0.0.4-beta.0.20240624100937-73632381301b h1
 github.com/prysmaticlabs/gohashtree v0.0.4-beta.0.20240624100937-73632381301b/go.mod h1:HRuvtXLZ4WkaB1MItToVH2e8ZwKwZPY5/Rcby+CvvLY=
 github.com/prysmaticlabs/prysm/v5 v5.3.0 h1:7Lr8ndapBTZg00YE+MgujN6+yvJR6Bdfn28ZDSJ00II=
 github.com/prysmaticlabs/prysm/v5 v5.3.0/go.mod h1:r1KhlduqDMIGZ1GhR5pjZ2Ko8Q89noTDYTRoPKwf1+c=
-github.com/pushchain/evm v1.0.0-rc2.0.20260518124843-b5053b7ed645 h1:je7kEfgAtoZiLizQ7+Pq50fHcMTyr8Hz1lc52gW8WPY=
-github.com/pushchain/evm v1.0.0-rc2.0.20260518124843-b5053b7ed645/go.mod h1:byHCefIPjWbQGgVbubMCBwwBDfhWuiPavb1x8YhMH9k=
+github.com/pushchain/evm v1.0.0-rc2.0.20260603074055-8f9a31adb5dc h1:N3KMIMNJ3jAWnpIxsyj/vBYbmnEdKIRr7MMvQsPSz/A=
+github.com/pushchain/evm v1.0.0-rc2.0.20260603074055-8f9a31adb5dc/go.mod h1:vKf+jvVTJOouZQ0dCYTGlktHaOO5MAhry7zK9RApElY=
 github.com/quic-go/qpack v0.4.0 h1:Cr9BXA1sQS2SmDUWjSofMPNKmvF6IiIfDRmgU0w1ZCo=
 github.com/quic-go/qpack v0.4.0/go.mod h1:UZVnYIfi5GRk+zI9UMaCPsmZ2xKJP7XBUvVyT1Knj9A=
 github.com/quic-go/qtls-go1-20 v0.3.4 h1:MfFAPULvst4yoMgY9QmtpYmfij/em7O8UUi+bNVm7Cg=

--- a/go.sum
+++ b/go.sum
@@ -1769,8 +1769,8 @@ github.com/prysmaticlabs/gohashtree v0.0.4-beta.0.20240624100937-73632381301b h1
 github.com/prysmaticlabs/gohashtree v0.0.4-beta.0.20240624100937-73632381301b/go.mod h1:HRuvtXLZ4WkaB1MItToVH2e8ZwKwZPY5/Rcby+CvvLY=
 github.com/prysmaticlabs/prysm/v5 v5.3.0 h1:7Lr8ndapBTZg00YE+MgujN6+yvJR6Bdfn28ZDSJ00II=
 github.com/prysmaticlabs/prysm/v5 v5.3.0/go.mod h1:r1KhlduqDMIGZ1GhR5pjZ2Ko8Q89noTDYTRoPKwf1+c=
-github.com/pushchain/evm v1.0.0-rc2.0.20260603074055-8f9a31adb5dc h1:N3KMIMNJ3jAWnpIxsyj/vBYbmnEdKIRr7MMvQsPSz/A=
-github.com/pushchain/evm v1.0.0-rc2.0.20260603074055-8f9a31adb5dc/go.mod h1:vKf+jvVTJOouZQ0dCYTGlktHaOO5MAhry7zK9RApElY=
+github.com/pushchain/evm v1.0.0-rc2.0.20260604090552-d3251a04c5b2 h1:aeXrv0vxp2NQimXbWiy4Wc9TIsC64Z41zocS8+ScgNY=
+github.com/pushchain/evm v1.0.0-rc2.0.20260604090552-d3251a04c5b2/go.mod h1:vKf+jvVTJOouZQ0dCYTGlktHaOO5MAhry7zK9RApElY=
 github.com/quic-go/qpack v0.4.0 h1:Cr9BXA1sQS2SmDUWjSofMPNKmvF6IiIfDRmgU0w1ZCo=
 github.com/quic-go/qpack v0.4.0/go.mod h1:UZVnYIfi5GRk+zI9UMaCPsmZ2xKJP7XBUvVyT1Knj9A=
 github.com/quic-go/qtls-go1-20 v0.3.4 h1:MfFAPULvst4yoMgY9QmtpYmfij/em7O8UUi+bNVm7Cg=


### PR DESCRIPTION
## Summary
- `go.mod` and `go.sum` update for `pushchain/evm`
- upgrade handler : `evm-rpc-fix` added
## References
- Fixes #
- Related issue/PR: https://github.com/pushchain/push-chain-evm/pull/14

## Changes
- `go.mod` and `go.sum` update for `pushchain/evm`
- upgrade handler : `evm-rpc-fix` added
## Testing
- `go test ./...`

## Checklist
- [ ] Ready for review
- [ ] Docs updated (if applicable)
- [ ] Env vars updated (if applicable)
