### PR TITLE
chore: evm v0.6.0 upgrade handler (donut)

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -8,39 +8,40 @@ import (
 	"github.com/pushchain/push-chain-node/app/upgrades"
 	aiauditfixes "github.com/pushchain/push-chain-node/app/upgrades/ai-audit-fixes"
 	aiauditfixes2 "github.com/pushchain/push-chain-node/app/upgrades/ai-audit-fixes-2"
-	purgeexpiredoutbounds "github.com/pushchain/push-chain-node/app/upgrades/purge-expired-outbounds"
-	removeutxverifier "github.com/pushchain/push-chain-node/app/upgrades/remove-utxverifier"
-	securityauditfixes "github.com/pushchain/push-chain-node/app/upgrades/security-audit-fixes"
-	tssfundmigrationfixes "github.com/pushchain/push-chain-node/app/upgrades/tss-fund-migration-fixes"
-	tssmigration "github.com/pushchain/push-chain-node/app/upgrades/tss-migration"
-	ueamigration "github.com/pushchain/push-chain-node/app/upgrades/uea-migration"
 	ceagasandpayload "github.com/pushchain/push-chain-node/app/upgrades/cea-gas-and-payload"
 	ceapayloadverificationfix "github.com/pushchain/push-chain-node/app/upgrades/cea-payload-verification-fix"
 	chainmeta "github.com/pushchain/push-chain-node/app/upgrades/chain-meta"
 	chainmetavotegasless "github.com/pushchain/push-chain-node/app/upgrades/chain-meta-vote-gasless"
 	contractauditchanges "github.com/pushchain/push-chain-node/app/upgrades/contract-audit-changes"
-	evmparamsmigration "github.com/pushchain/push-chain-node/app/upgrades/evm-params-migration"
-	evmchainidffix "github.com/pushchain/push-chain-node/app/upgrades/evm-chainid-fix"
-	evmpreinstalls "github.com/pushchain/push-chain-node/app/upgrades/evm-preinstalls"
 	ethhashfix "github.com/pushchain/push-chain-node/app/upgrades/eth-hash-fix"
 	evmblockscoutfix "github.com/pushchain/push-chain-node/app/upgrades/evm-blockscout-fix"
+	evmchainidffix "github.com/pushchain/push-chain-node/app/upgrades/evm-chainid-fix"
+	evmparamsmigration "github.com/pushchain/push-chain-node/app/upgrades/evm-params-migration"
+	evmpreinstalls "github.com/pushchain/push-chain-node/app/upgrades/evm-preinstalls"
 	evmrpcfix "github.com/pushchain/push-chain-node/app/upgrades/evm-rpc-fix"
 	evmv040 "github.com/pushchain/push-chain-node/app/upgrades/evm-v0-4-0"
 	evmv050 "github.com/pushchain/push-chain-node/app/upgrades/evm-v0-5-0"
+	evmv060 "github.com/pushchain/push-chain-node/app/upgrades/evm-v0-6-0"
 	feeabs "github.com/pushchain/push-chain-node/app/upgrades/fee-abs"
 	gasoracle "github.com/pushchain/push-chain-node/app/upgrades/gas-oracle"
 	"github.com/pushchain/push-chain-node/app/upgrades/noop"
 	outbound "github.com/pushchain/push-chain-node/app/upgrades/outbound"
 	pcmintcap "github.com/pushchain/push-chain-node/app/upgrades/pc-mint-cap"
 	proxybytecodefix "github.com/pushchain/push-chain-node/app/upgrades/proxy-bytecode-fix"
+	purgeexpiredoutbounds "github.com/pushchain/push-chain-node/app/upgrades/purge-expired-outbounds"
 	removefeeabsv1 "github.com/pushchain/push-chain-node/app/upgrades/remove-fee-abs-v1"
+	removeutxverifier "github.com/pushchain/push-chain-node/app/upgrades/remove-utxverifier"
+	securityauditfixes "github.com/pushchain/push-chain-node/app/upgrades/security-audit-fixes"
 	solanafix "github.com/pushchain/push-chain-node/app/upgrades/solana-fix"
 	supplyburn "github.com/pushchain/push-chain-node/app/upgrades/supply-burn"
 	supplyslash "github.com/pushchain/push-chain-node/app/upgrades/supply-slash"
 	tsscore "github.com/pushchain/push-chain-node/app/upgrades/tss-core"
 	tsscoreevmparamsfix "github.com/pushchain/push-chain-node/app/upgrades/tss-core-evm-params-fix"
 	tsscorefix "github.com/pushchain/push-chain-node/app/upgrades/tss-core-fix"
+	tssfundmigrationfixes "github.com/pushchain/push-chain-node/app/upgrades/tss-fund-migration-fixes"
+	tssmigration "github.com/pushchain/push-chain-node/app/upgrades/tss-migration"
 	tssvotegasless "github.com/pushchain/push-chain-node/app/upgrades/tss-vote-gasless"
+	ueamigration "github.com/pushchain/push-chain-node/app/upgrades/uea-migration"
 	universaltxv1 "github.com/pushchain/push-chain-node/app/upgrades/universal-tx-v1"
 )
 
@@ -81,6 +82,8 @@ var Upgrades = []upgrades.Upgrade{
 	evmpreinstalls.NewUpgrade(),
 	evmv050.NewUpgrade(),
 	securityauditfixes.NewUpgrade(),
+	// cosmos/evm v0.6.0 — runs the standard transfer module v5->v6 migration
+	evmv060.NewUpgrade(),
 }
 
 // RegisterUpgradeHandlers registers the chain upgrade handlers
@@ -103,10 +106,10 @@ func (app *ChainApp) RegisterUpgradeHandlers() {
 		BankKeeper:            app.BankKeeper,
 
 		// Module keepers
-		UExecutorKeeper:   &app.UexecutorKeeper,
-		URegistryKeeper:   &app.UregistryKeeper,
-		UValidatorKeeper:  &app.UvalidatorKeeper,
-		UTssKeeper:        &app.UtssKeeper,
+		UExecutorKeeper:  &app.UexecutorKeeper,
+		URegistryKeeper:  &app.UregistryKeeper,
+		UValidatorKeeper: &app.UvalidatorKeeper,
+		UTssKeeper:       &app.UtssKeeper,
 	}
 
 	// register all upgrade handlers

--- a/app/upgrades/evm-v0-6-0/upgrade.go
+++ b/app/upgrades/evm-v0-6-0/upgrade.go
@@ -1,0 +1,64 @@
+package evmv060
+
+import (
+	"context"
+	"fmt"
+
+	storetypes "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/pushchain/push-chain-node/app/upgrades"
+)
+
+// UpgradeName is the on-chain name of the cosmos/evm v0.6.0 upgrade. It MUST
+// match the `plan.name` used in the MsgSoftwareUpgrade governance proposal.
+const UpgradeName = "evm-v0.6.0"
+
+// NewUpgrade constructs the upgrade definition for the cosmos/evm v0.6.0 upgrade.
+//
+// Context: cosmos/evm v0.6.0 removed its bundled x/ibc/transfer wrapper, so
+// push-chain now uses the standard ibc-go v10 transfer module (with the erc20
+// IBC middleware wired in app.go). The "transfer" module therefore moves from
+// ConsensusVersion 5 (the removed custom wrapper) to 6 (the standard module),
+// which makes RunMigrations run the standard transfer v5->v6 migration
+// (MigrateDenomTraceToDenom).
+//
+// No store keys are added or removed — the transfer module keeps the same store
+// key (ibctransfertypes.StoreKey) — so StoreUpgrades is empty. None of the evm
+// modules (vm, erc20, feemarket, precisebank) bumped their ConsensusVersion.
+func NewUpgrade() upgrades.Upgrade {
+	return upgrades.Upgrade{
+		UpgradeName:          UpgradeName,
+		CreateUpgradeHandler: CreateUpgradeHandler,
+		StoreUpgrades: storetypes.StoreUpgrades{
+			Added:   []string{},
+			Deleted: []string{},
+		},
+	}
+}
+
+// CreateUpgradeHandler runs the standard module migrations. RunMigrations walks
+// every module from the stored version map to its current ConsensusVersion, so
+// the transfer v5->v6 migration (and any other pending module migration bundled
+// in this release) is executed automatically.
+func CreateUpgradeHandler(
+	mm upgrades.ModuleManager,
+	configurator module.Configurator,
+	_ *upgrades.AppKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx context.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		logger := sdk.UnwrapSDKContext(ctx).Logger().With("upgrade", UpgradeName)
+		logger.Info("starting cosmos/evm v0.6.0 upgrade: running module migrations (transfer v5->v6)")
+
+		versionMap, err := mm.RunMigrations(ctx, configurator, fromVM)
+		if err != nil {
+			return nil, fmt.Errorf("run migrations: %w", err)
+		}
+
+		logger.Info("cosmos/evm v0.6.0 upgrade complete")
+		return versionMap, nil
+	}
+}


### PR DESCRIPTION
Adds the `evm-v0.6.0` upgrade handler on top of the donut testnet lineage (feature already merged via #281).

- new `app/upgrades/evm-v0-6-0/upgrade.go` (UpgradeName `evm-v0.6.0`) — runs standard module migrations (transfer v5→v6 from cosmos/evm v0.6.0 dropping its bundled ibc-transfer wrapper); empty StoreUpgrades.
- registered in `app/upgrades.go` **after** `securityauditfixes` (donut's current live upgrade), so it is the next upgrade in donut's sequence.\n\nCherry-picked from the feature branch's handler commit (`06c83206`); the `app/upgrades.go` conflict was resolved by keeping donut's existing ~34 handlers and appending this one.\n\n**Before merging/proposing:** confirm the plan name in the `MsgSoftwareUpgrade` proposal is exactly `evm-v0.6.0`, and validate via upgrade simulation (OLD = current donut binary, NEW = this branch).