### PR TITLE
fix(test_node): inject bank denom_metadata for local sh-testnet

### DIFF
--- a/scripts/test_node.sh
+++ b/scripts/test_node.sh
@@ -112,6 +112,10 @@ from_scratch () {
   update_test_genesis '.app_state["gov"]["params"]["expedited_voting_period"]="15s"'
 
   update_test_genesis `printf '.app_state["evm"]["params"]["evm_denom"]="%s"' $DENOM`
+  # cosmos/evm v0.5+ derives EVM coin info from bank denom_metadata at InitGenesis
+  # (LoadEvmCoinInfo); without metadata for the base denom the node panics on start
+  # with "denom metadata <denom> could not be found".
+  update_test_genesis '.app_state["bank"]["denom_metadata"]=[{"description":"Native token of Push Chain","denom_units":[{"denom":"upc","exponent":0,"aliases":[]},{"denom":"pushchain","exponent":18,"aliases":[]}],"base":"upc","display":"pushchain","name":"Push Chain","symbol":"PC"}]'
   update_test_genesis '.app_state["evm"]["params"]["active_static_precompiles"]=["0x00000000000000000000000000000000000000CB","0x00000000000000000000000000000000000000ca","0x0000000000000000000000000000000000000100","0x0000000000000000000000000000000000000400","0x0000000000000000000000000000000000000800","0x0000000000000000000000000000000000000801","0x0000000000000000000000000000000000000802","0x0000000000000000000000000000000000000803","0x0000000000000000000000000000000000000804","0x0000000000000000000000000000000000000805"]'
   update_test_genesis '.app_state["erc20"]["params"]["native_precompiles"]=["0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"]' # https://eips.ethereum.org/EIPS/eip-7528
   update_test_genesis `printf '.app_state["erc20"]["token_pairs"]=[{contract_owner:1,erc20_address:"0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",denom:"%s",enabled:true}]' $DENOM`


### PR DESCRIPTION
Local devnet fix (no chain-code change).

`scripts/test_node.sh` sets `evm_denom` but never injects bank `denom_metadata`. cosmos/evm v0.5+ derives EVM coin info from bank metadata at InitGenesis (`LoadEvmCoinInfo`), so `make sh-testnet` panics on start:

```
panic: error initializing evm coin info: denom metadata upc could not be found
```

This adds the `upc` metadata (same shape as the interchaintest genesis) right after the `evm_denom` line. Verified: `make sh-testnet` boots cleanly and was used to run the evm-v0.6.0 upgrade simulation end-to-end.