### PR TITLE
feat(upgrades): sdk-v0.53 upgrade handler (Cosmos SDK v0.50.10 -> v0.53.7)

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -32,6 +32,7 @@ import (
 	purgeexpiredoutbounds "github.com/pushchain/push-chain-node/app/upgrades/purge-expired-outbounds"
 	removefeeabsv1 "github.com/pushchain/push-chain-node/app/upgrades/remove-fee-abs-v1"
 	removeutxverifier "github.com/pushchain/push-chain-node/app/upgrades/remove-utxverifier"
+	sdkv053 "github.com/pushchain/push-chain-node/app/upgrades/sdk-v0-53"
 	securityauditfixes "github.com/pushchain/push-chain-node/app/upgrades/security-audit-fixes"
 	solanafix "github.com/pushchain/push-chain-node/app/upgrades/solana-fix"
 	supplyburn "github.com/pushchain/push-chain-node/app/upgrades/supply-burn"
@@ -87,6 +88,8 @@ var Upgrades = []upgrades.Upgrade{
 	evmv060.NewUpgrade(),
 	// pc20 — no-op binary swap; VAULT_PC/VAULT_PC20 deployed separately from EVM side
 	pc20.NewUpgrade(),
+	// sdk-v0.53 — Cosmos SDK v0.50.10 -> v0.53.7; no-op (no module ConsensusVersion changes)
+	sdkv053.NewUpgrade(),
 }
 
 // RegisterUpgradeHandlers registers the chain upgrade handlers

--- a/app/upgrades/sdk-v0-53/upgrade.go
+++ b/app/upgrades/sdk-v0-53/upgrade.go
@@ -1,0 +1,64 @@
+package sdkv053
+
+import (
+	"context"
+	"fmt"
+
+	storetypes "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/pushchain/push-chain-node/app/upgrades"
+)
+
+// UpgradeName is the on-chain name of the Cosmos SDK v0.53 upgrade. It MUST
+// match the `plan.name` used in the MsgSoftwareUpgrade governance proposal.
+const UpgradeName = "sdk-v0.53"
+
+// NewUpgrade constructs the upgrade definition for the Cosmos SDK
+// v0.50.10 -> v0.53.7 bump.
+//
+// This is a NO-OP state upgrade. v0.53 is an additive release over v0.50: none
+// of the modules this chain registers bumped its ConsensusVersion (auth, bank,
+// staking, gov, distribution, slashing, mint, consensus, authz, evidence,
+// feegrant, circuit, group, nft — all unchanged 0.50->0.53), and no new store
+// keys are added. v0.53's new modules (x/epochs, x/protocolpool) are not adopted,
+// and the new unordered-transaction nonces live under a key prefix inside the
+// existing x/auth store (unordered txs are left disabled). So StoreUpgrades is
+// empty and RunMigrations is a no-op; the handler only swaps the chain to the
+// v0.53 binary and resumes block production.
+func NewUpgrade() upgrades.Upgrade {
+	return upgrades.Upgrade{
+		UpgradeName:          UpgradeName,
+		CreateUpgradeHandler: CreateUpgradeHandler,
+		StoreUpgrades: storetypes.StoreUpgrades{
+			Added:   []string{},
+			Deleted: []string{},
+		},
+	}
+}
+
+// CreateUpgradeHandler runs the standard module migrations. Because no module
+// ConsensusVersion changed across the SDK v0.50 -> v0.53 bump, RunMigrations
+// walks the version map and finds nothing to migrate (a no-op), then returns the
+// current version map so the chain resumes on the new binary.
+func CreateUpgradeHandler(
+	mm upgrades.ModuleManager,
+	configurator module.Configurator,
+	_ *upgrades.AppKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx context.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		logger := sdk.UnwrapSDKContext(ctx).Logger().With("upgrade", UpgradeName)
+		logger.Info("starting Cosmos SDK v0.53 upgrade (no-op: binary swap only; no module ConsensusVersion changes)")
+
+		versionMap, err := mm.RunMigrations(ctx, configurator, fromVM)
+		if err != nil {
+			return nil, fmt.Errorf("run migrations: %w", err)
+		}
+
+		logger.Info("Cosmos SDK v0.53 upgrade complete")
+		return versionMap, nil
+	}
+}


### PR DESCRIPTION
## What

Adds a named chain-upgrade handler for the Cosmos SDK **v0.50.10 → v0.53.7** bump (the dependency change landed on `testnet/donut` via #284 → #289).

- `app/upgrades/sdk-v0-53/upgrade.go` — `UpgradeName = "sdk-v0.53"`, registered in `app/upgrades.go` after `pc20`.
- **No-op handler**: `RunMigrations` + empty `StoreUpgrades`. No module ConsensusVersion changed across 0.50→0.53 (auth 5, bank 4, staking 5, gov 5, distribution 3, slashing 4, mint 2, consensus 1, authz 2, evidence 1, feegrant 2, circuit 1, group 2, nft 1), and no new store keys are added — v0.53's new modules (x/epochs, x/protocolpool) are not adopted, and the new unordered-tx nonces live under a key prefix inside the existing x/auth store (unordered txs remain disabled). So there is no state migration; the handler swaps the binary and resumes.

## Why

The SDK bump reached `testnet/donut` as a binary-only change. This adds a governance-triggerable named upgrade so the swap can be rolled out via `MsgSoftwareUpgrade` with `plan.name = "sdk-v0.53"`, instead of relying on the empty-`Upgrades` `app.Version()` noop fallback.

## Testing

Local upgrade simulation `release/v1.1.37-donut` (SDK 0.50) → this branch (SDK 0.53) passed end-to-end:

- proposal `sdk-v0.53` passed → chain halted at height 403 (`UPGRADE "sdk-v0.53" NEEDED` → deliberate consensus halt) → cosmovisor swapped to the new binary → handler ran (`starting Cosmos SDK v0.53 upgrade` → `Cosmos SDK v0.53 upgrade complete`) → blocks resumed.
- `query upgrade applied sdk-v0.53` = 403, upgrade plan consumed, chain advancing on the v0.53 binary (0.0.42).
