### PR TITLE
chore: bump cosmos/evm to derived-tx gas price fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ replace (
 	cosmossdk.io/x/upgrade => cosmossdk.io/x/upgrade v0.2.0
 	github.com/CosmWasm/wasmd => github.com/CosmWasm/wasmd v0.55.0 // Keep v0.55.0
 	github.com/cosmos/cosmos-sdk => github.com/cosmos/cosmos-sdk v0.53.7 // Use stable v0.53.7
-	github.com/cosmos/evm => github.com/pushchain/evm v1.0.0-rc2.0.20260627105801-6c22ba0b1e9e
+	github.com/cosmos/evm => github.com/pushchain/evm v1.0.0-rc2.0.20260803072921-2d248e1881bb
 	github.com/ethereum/go-ethereum => github.com/cosmos/go-ethereum v0.0.0-20250806193535-2fc7571efa91
 	github.com/spf13/viper => github.com/spf13/viper v1.17.0
 	github.com/strangelove-ventures/tokenfactory => github.com/strangelove-ventures/tokenfactory v0.50.7-wasmvm2

--- a/go.sum
+++ b/go.sum
@@ -1769,8 +1769,8 @@ github.com/prysmaticlabs/gohashtree v0.0.4-beta.0.20240624100937-73632381301b h1
 github.com/prysmaticlabs/gohashtree v0.0.4-beta.0.20240624100937-73632381301b/go.mod h1:HRuvtXLZ4WkaB1MItToVH2e8ZwKwZPY5/Rcby+CvvLY=
 github.com/prysmaticlabs/prysm/v5 v5.3.0 h1:7Lr8ndapBTZg00YE+MgujN6+yvJR6Bdfn28ZDSJ00II=
 github.com/prysmaticlabs/prysm/v5 v5.3.0/go.mod h1:r1KhlduqDMIGZ1GhR5pjZ2Ko8Q89noTDYTRoPKwf1+c=
-github.com/pushchain/evm v1.0.0-rc2.0.20260627105801-6c22ba0b1e9e h1:KL2DPaFKZ7t7SkXnFQ/V5QEjvPE45Il5AyQvoVWFoMI=
-github.com/pushchain/evm v1.0.0-rc2.0.20260627105801-6c22ba0b1e9e/go.mod h1:QuenX5DgRhWeYdIg0J/p65cyS/ntpgnzpZOIajZ/SHk=
+github.com/pushchain/evm v1.0.0-rc2.0.20260803072921-2d248e1881bb h1:Ny+O67qLEZpO2UxnPJCpElw5YXfAiWsUcIuJJ1PMayA=
+github.com/pushchain/evm v1.0.0-rc2.0.20260803072921-2d248e1881bb/go.mod h1:QuenX5DgRhWeYdIg0J/p65cyS/ntpgnzpZOIajZ/SHk=
 github.com/quic-go/qpack v0.4.0 h1:Cr9BXA1sQS2SmDUWjSofMPNKmvF6IiIfDRmgU0w1ZCo=
 github.com/quic-go/qpack v0.4.0/go.mod h1:UZVnYIfi5GRk+zI9UMaCPsmZ2xKJP7XBUvVyT1Knj9A=
 github.com/quic-go/qtls-go1-20 v0.3.4 h1:MfFAPULvst4yoMgY9QmtpYmfij/em7O8UUi+bNVm7Cg=


### PR DESCRIPTION
Bumps the `cosmos/evm` pin to pick up [push-chain-evm#37](https://github.com/pushchain/push-chain-evm/pull/37).

```diff
- github.com/cosmos/evm => github.com/pushchain/evm v1.0.0-rc2.0.20260627105801-6c22ba0b1e9e
+ github.com/cosmos/evm => github.com/pushchain/evm v1.0.0-rc2.0.20260803072921-2d248e1881bb
```

## What it fixes

Blocks whose only content is **derived transactions** (protocol-internal, not user-signed) render a
**negative block reward** in explorers. Derived txs are reconstructed from ABCI events, which carry no
fee data, so they are rebuilt with `GasFeeCap = GasTipCap = 0` and the EIP-1559 formula resolves their
price to `0` — while the receipt still reports `gasUsed > 0`.

Blockscout computes a block's reward as `Σ(gas_used × gas_price) − base_fee × Σ(gas_used)`, which for a
derived-only block goes negative. Reproduced on live donut (block `0x13a5ce8`):

```
effectiveGasPrice 0x0 · gasUsed 0xb2dc · baseFeePerGas 0x3b9aca00
reward = 45788×0 − 1e9×45788 = -45,788,000,000,000
```

The fix reports the block base fee as the derived tx's `gasPrice` and receipt `effectiveGasPrice`, so
the arithmetic nets to exactly zero — matching the chain's real economics, since a derived tx pays
nothing to the proposer and burns nothing.

**JSON-RPC reporting only — no consensus, no state changes.**

## Scope

`go.mod` + `go.sum` only. `go build ./...` clean.

An upgrade simulation from `release/v1.1.38-donut` (currently deployed on donut) to this branch was run
locally to validate the binary swap. No upgrade handler is required or included — the change is not
state-breaking.